### PR TITLE
fix: use correct path for getting fills by client id

### DIFF
--- a/enclave/_perps.py
+++ b/enclave/_perps.py
@@ -367,9 +367,9 @@ class Perps:
         if (not any((client_order_id, order_id))) or all((client_order_id, order_id)):
             raise ValueError("Must provide exactly one of client_order_id or order_id")
 
-        path = f"/v1/perps/fills/client:{client_order_id}" if client_order_id else f"/v1/perps/orders/{order_id}/fills"
+        path = f"client:{client_order_id}" if client_order_id else order_id
 
-        return self.bc.get(path)
+        return self.bc.get(f"/v1/perps/orders/{path}/fills")
 
     def get_fills_csv(
         self, market: Optional[str] = None, *, start_ms: Optional[int] = None, end_ms: Optional[int] = None

--- a/enclave/_spot.py
+++ b/enclave/_spot.py
@@ -150,16 +150,16 @@ class Spot:
         Fills by Order ID
         Exactly one of client_order_id (clientOrderID) or internal order_id (orderID) must be provided.
 
-        `GET /v1/fills/client:{clientOrderID}` if client_order_id
+        `GET /v1/orders/client:{orderID}/fills` if client_order_id
         or
         `GET /v1/orders/{orderID}/fills` if order_id (internal)"""
 
         if (not any((client_order_id, order_id))) or all((client_order_id, order_id)):
             raise ValueError("Must provide exactly one of client_order_id or order_id")
 
-        path = f"/v1/fills/client:{client_order_id}" if client_order_id else f"/v1/orders/{order_id}/fills"
+        path = f"client:{client_order_id}" if client_order_id else order_id
 
-        return self.bc.get(path)
+        return self.bc.get(f"/v1/orders/{path}/fills")
 
     def get_fills_csv(
         self, market: Optional[str] = None, *, start_ms: Optional[int] = None, end_ms: Optional[int] = None

--- a/examples/intro.py
+++ b/examples/intro.py
@@ -54,6 +54,28 @@ def spot(client: Client) -> None:
     filled_size = Decimal(order_status["filledSize"])
     print(f"{filled_size=}")
 
+    # cause a trade and query fills
+    custom_id = f"demo{int(time.time_ns())}"
+    sell_order = client.spot.add_order(
+        "AVAX-USDC",
+        enclave.models.SELL,
+        None,
+        avax_base_min,
+        order_type=enclave.models.MARKET,
+        client_order_id=custom_id,
+    ).json()["result"]
+
+    print(f"{sell_order=}")
+    
+    fills_by_custom_id = client.spot.get_fills_by_id(client_order_id=custom_id).json()["result"]
+    print(f"found {len(fills_by_custom_id)} fills by custom id")
+
+    fills_by_order_id = client.spot.get_fills_by_id(order_id=sell_order["orderId"]).json()["result"]
+    print(f"found {len(fills_by_order_id)} fills by order id")
+
+    all_fills = client.spot.get_fills().json()["result"]
+    print(f"found {len(all_fills)} fills for all orders")
+
 
 def perps(client: Client) -> None:
     """Demonstrate some perps trading functionality."""
@@ -118,6 +140,30 @@ def perps(client: Client) -> None:
     filled_size = Decimal(order_status["filledSize"])
     print(f"{filled_size=}")
 
+    # cause a trade and query fills
+    custom_id = f"demo{int(time.time_ns())}"
+    buy_order = client.perps.add_order(
+        "BTC-USD.P",
+        enclave.models.BUY,
+        None,
+        buy_size,
+        order_type=enclave.models.MARKET,
+        client_order_id=custom_id,
+    ).json()["result"]
+    print(f"{buy_order=}")
+
+    positions = client.perps.get_positions().json()["result"]
+    print(f"{positions=}")
+
+    fills_by_custom_id = client.perps.get_fills_by_id(client_order_id=custom_id).json()["result"]
+    print(f"found {len(fills_by_custom_id)} fills by custom id")
+
+    fills_by_order_id = client.perps.get_fills_by_id(order_id=buy_order["orderId"]).json()["result"]
+    print(f"found {len(fills_by_order_id)} fills by order id")
+
+    all_fills = client.perps.get_fills().json()["result"]
+    print(f"found {len(all_fills)} fills for all orders")
+
     margin_withdraw = client.perps.transfer("USDC", Decimal(-1)).json()
     print(f"{margin_withdraw=}")
     margin_balance = client.perps.get_balance().json()
@@ -163,6 +209,15 @@ def cross(client: Client) -> None:
     order_status = client.cross.get_order(customer_order_id=custom_id).json()["result"]
     print(f"{order_status=}")
     print(f"amount filled: {order_status['filledSize']=}, status: {order_status['status']=}")
+
+    fills_by_custom_id = client.cross.get_fills_by_id(customer_order_id=custom_id).json()["result"]
+    print(f"found {len(fills_by_custom_id)} fills by custom id")
+
+    fills_by_order_id = client.cross.get_fills_by_id(internal_order_id=buy_order["result"]["internalOrderId"]).json()["result"]
+    print(f"found {len(fills_by_order_id)} fills by order id")
+
+    all_fills = client.cross.get_fills().json()["result"]
+    print(f"found {len(all_fills)} fills for all orders")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

**Problem:** The client was using the wrong path for getting the fills by a client-order-id. It was using an old path:
```
/v1/fills/client:{clientOrderID}
```

when the correct one is:
```
/v1/orders/cllient:{clientOrderID}/fills
```

**Solution:** Update the cllient.

**Testing/Examples:** The examples in `intro.py` have been extended to get that all fills API work.
```
Running spot example...
********************************************************************************
Free AVAX balance: balance=Decimal('10000.008362')
.
.
.
sell_order={'orderId': '5A6WUGMXIETTTWG6RQ4P73VAACD5IMNQ', 'clientOrderId': 'demo1731936926970485000', 'side': 'sell', 'price': '0', 'size': '0.001', 'market': 'AVAX-USDC', 'filledSize': '0.001', 'filledCost': '0.04081', 'fee': '0', 'status': 'fullyfilled', 'createdAt': '2024-11-18T13:35:27.052053935Z', 'filledAt': '2024-11-18T13:35:27.052053935Z', 'type': 'market'}
found 1 fills by custom id
found 1 fills by order id
found 20 fills for all orders

Running perps example...
********************************************************************************
Free USDC balance: usdc_balance=Decimal('1228.72553')
margin_deposit={'success': True, 'result': {'id': '5899726075655648239', 'from': {'id': '17621454918615412793', 'wallet': 'main'}, 'to': {'id': '17621454918615412793', 'wallet': 'margin'}, 'amount': '1', 'symbol': 'USDC', 'time': '2024-11-18T13:35:27.716053151Z', 'type': 0}}
.
.
.
found 1 fills by custom id
found 1 fills by order id
found 19 fills for all orders
margin_withdraw={'success': True, 'result': {'id': '307278890129673110', 'from': {'id': '17621454918615412793', 'wallet': 'margin'}, 'to': {'id': '17621454918615412793', 'wallet': 'main'}, 'amount': '1', 'symbol': 'USDC', 'time': '2024-11-18T13:35:29.328051249Z', 'type': 0}}
margin_balance={'success': True, 'result': {'walletBalance': '279.840764', 'realizedPnl': '1.395999', 'unrealizedPnl': '89.20128', 'marginBalance': '369.042044', 'usedMargin': '32.387528', 'availableMargin': '336.654516', 'withdrawableMargin': '279.840764', 'maintenanceMarginRequirement': '16.193764', 'marginRatio': '0.0439', 'leverage': '0.9', 'underLiquidation': False}}

Running cross example...
********************************************************************************
Free USDC balance: balance=Decimal('1228.72553')
.
.
.
found 1 fills by custom id
found 1 fills by order id
found 6 fills for all orders

```
