### PR TITLE
feat: add permissionless functionality to public python API client

### DIFF
--- a/enclave/__init__.py
+++ b/enclave/__init__.py
@@ -1,2 +1,2 @@
 """Python SDK for Enclave Markets API"""
-__version__ = "0.2.0"
+__version__ = "0.3.1"

--- a/enclave/client.py
+++ b/enclave/client.py
@@ -39,7 +39,8 @@ class Client:
         self.perps = _perps.Perps(self.bc)
         self.spot = _spot.Spot(self.bc)
         
-        # Fetch and store account ID during initialization
+        self.wait_until_ready()
+
         response = self.authed_hello()
         if response.ok:
             self.account_id = response.json()["result"]

--- a/enclave/client.py
+++ b/enclave/client.py
@@ -216,7 +216,7 @@ class Client:
         }
         ```"""
 
-        body = {"symbol": coin}
+        body: dict[str, Union[str, dict[str, str]]] = {"symbol": coin}
         if wallet is not None:
             if wallet not in ["main", "margin"]:
                 raise ValueError("wallet must be either 'main' or 'margin'")
@@ -242,7 +242,7 @@ class Client:
         }
         ```"""
 
-        body = {
+        body: dict[str, Union[str, dict[str, str]]] = {
             "address": to_address,
             "amount": str(amount),
             "customer_withdrawal_id": custom_id,

--- a/enclave/models.py
+++ b/enclave/models.py
@@ -11,8 +11,12 @@ PUT: Final[str] = "PUT"
 VERBS: Final[Set[str]] = {GET, POST, DELETE, PUT}
 
 DEV: Final[str] = "https://api-dev.enclavemarket.dev"
-PROD: Final[str] = "https://api.enclave.market"
+DEV_PERMISSIONLESS: Final[str] = "https://api-dev-permissionless.enclavemarket.dev"
+STAGING: Final[str] = "https://api-staging.enclavemarket.dev"
 SANDBOX: Final[str] = "https://api-sandbox.enclave.market"
+SANDBOX_PERMISSIONLESS: Final[str] = "https://api-sandbox.enclave.trade"
+PROD: Final[str] = "https://api.enclave.market"
+PROD_PERMISSIONLESS: Final[str] = "https://api.enclave.trade"
 
 BUY: Final[str] = "buy"
 SELL: Final[str] = "sell"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enclave"
-version = "0.3.0"
+version = "0.3.1"
 description = "Connect to Enclave Markets API"
 authors = ["benclave <ben@enclave.market>"]
 readme = "README.md"


### PR DESCRIPTION
# Description
We have recently added several new perpetuals-only environments and need to update the python client for them. 

**Problem:** Missing endpoints in models, no support for direct-to and direct-from margin deposits and withdrawals. 

**Solution:** Add it. 

**Testing/Examples:** 
```
import os

import enclave.models
from enclave.client import Client

API_KEY = str(os.getenv("enclave_key"))
API_SECRET = str(os.getenv("enclave_secret"))

client = Client("<key>", "<secret>", enclave.models.DEV_PERMISSIONLESS)

print("Provisioning address")
res = client.provision_address("USDC", wallet="margin")
print(res.json())

print("Withdrawing")
res = client.withdraw("0x1816fc7A0142ee126e980F3F2DD1479a20e04682", "1", "test-withdraw", "USDC", wallet="margin")
print(res.json())
```

```
~/enclave-python-1 (jesse/permissionless-python-client*) » PYTHONPATH=. python examples/permissionless_test.py                                                                       jesse.braun@AVL-9MHGFG
Provisioning address
{'success': True, 'result': {'accountId': '4243739687171838759', 'symbol': 'USDC', 'address': '0xd513a2d5b9857b8caa5bf0129b70e7a751b8ff47'}}
Withdrawing
{'success': True, 'result': {'withdrawal_status': 'WITHDRAWAL_PENDING', 'withdrawal_id': '884e928c00995afe02d5316a820cdfca8a8cdb9d4d3336352d414998de77ea61omni25', 'customer_withdrawal_id': 'test-withdraw', 'hash': '0x008ce905b89da2101fdffd1d63c2db1179269ec04fdb89d54dac5ecd62b028fd'}}
```

Deposited to the provisioned address and it showed up. 
![image](https://github.com/user-attachments/assets/ce919257-d485-4f78-be8b-bd7c302794dc)

Withdrawal went through. 
![image](https://github.com/user-attachments/assets/bc8b9a78-56d9-4096-ac9b-66ce46d8090f)

