### PR TITLE
Wwestgarth/add contracts endpoint

### DIFF
--- a/enclave/__init__.py
+++ b/enclave/__init__.py
@@ -1,2 +1,2 @@
 """Python SDK for Enclave Markets API"""
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/enclave/_perps.py
+++ b/enclave/_perps.py
@@ -495,3 +495,19 @@ class Perps:
             body["orders"].append({k: v for k, v in order_body.items() if v is not None})  # filter None
 
         return self.bc.post("/v1/perps/orders/batch", body=json.dumps(body))
+
+    def get_contracts(
+        self, sparkline: Optional[bool] = None
+    ) -> Res:
+        """
+        Return contract data, such as 24hr market data, for each available Perpetual market.
+
+        `GET /v1/perps/contracts`
+
+        Request Body Parameters:
+        - sparkline: Whether to include sparkline data for each market in the response
+        """
+        query = {
+            "sparkline": sparkline,
+        }
+        return self.bc.get("/v1/perps/contracts", params=query)

--- a/enclave/_spot.py
+++ b/enclave/_spot.py
@@ -287,3 +287,17 @@ class Spot:
             body["orders"].append({k: v for k, v in order_body.items() if v is not None})  # filter None
 
         return self.bc.post("/v1/orders/batch", body=json.dumps(body))
+
+
+    def get_ticker(
+        self, sparkline: Optional[bool] = None
+    ) -> Res:
+        """
+        Return ticker data, such as 24hr market data, for each available Spot market.
+
+        `GET /v1/ticker`
+        """
+        query = {
+            "sparkline": sparkline,
+        }
+        return self.bc.get("/v1/ticker", params=query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enclave"
-version = "0.3.2"
+version = "0.3.3"
 description = "Connect to Enclave Markets API"
 authors = ["benclave <ben@enclave.market>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

**Problem:** 
We have the endpoint `v1/perps/contracts` that contain useful market data for each perpetual-futures markets. The end-point also contains an `isClosed` field which can be used to determine whether the underlying market for RWA's are closed.

Given we want to roll out more RWA alpha-strats etc. etc. it would make sense for this field to be available to any strat-managers that are using the python client.

**Solution:**
Add methods on the enclave-python client to call into the contracts endpoint. I have also added the equivalent endpoint for spot markets.

**Testing/Examples:** 
Locally ran the following:
```
def main():

    # create a client
    enclave_client = Client(API_KEY, API_SECRET, enclave.models.SANDBOX)
    if not enclave_client.wait_until_ready():
        raise RuntimeError("Enclave not connecting.")
    
    print(enclave_client.perps.get_contracts().json())
    print(enclave_client.spot.get_ticker().json())
```
